### PR TITLE
Fixed typo on last line of %environment

### DIFF
--- a/Singularity.v0.1.1
+++ b/Singularity.v0.1.1
@@ -172,7 +172,7 @@ export LD_LIBRARY_PATH=/usr/lib/fsl/5.0
 #mcr
 export MCR_VERSION=v91
 export LD_LIBRARY_PATH=/opt/mcr/${MCR_VERSION}/runtime/glnxa64:/opt/mcr/${MCR_VERSION}/bin/glnxa64:/opt/mcr/${MCR_VERSION}/sys/os/glnxa64:/opt/mcr/${MCR_VERSION}/sys/opengl/lib/glnxa64:${LD_LIBRARY_PATH}
-export=MCR_INHIBIT_CTF_LOCK 1
+export=MCR_INHIBIT_CTF_LOCK=1
 
 
 #########


### PR DESCRIPTION
Was a non-fatal error, but should correct the error message: 

/.singularity.d/actions/shell: 28: /.singularity.d/env/90-environment.sh: 1: not found